### PR TITLE
bugfix Lock::timedWait not works as expected

### DIFF
--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -285,8 +285,13 @@ void Lock::wait(bool reset)
 bool Lock::timedWait(size_t ms, bool reset)
 {
     struct timespec ts;
-    ts.tv_sec = time(0) + ms / 1000;
-    ts.tv_nsec = (ms % 1000) * 1000 * 1000;
+    if (clock_gettime(CLOCK_REALTIME,&ts ) < 0 )
+        return false;
+
+    ts.tv_sec += (ms / 1000);
+    ts.tv_nsec += ((ms % 1000) * 1000 * 1000);
+    ts.tv_sec += ts.tv_nsec / 1e+9; // Nanoseconds [0 .. 999999999]
+    ts.tv_nsec = ts.tv_nsec % (int)1e+9;
 
     pdata_->notify_ = false;
     if (reset)


### PR DESCRIPTION
In UNIX API ‘sem_timedwait’， argument timedout is a absolute timestamp.